### PR TITLE
Disable secret store by default

### DIFF
--- a/compose-files/gateway.yml
+++ b/compose-files/gateway.yml
@@ -10,7 +10,6 @@ services:
         ipv4_address: 172.15.0.17
     depends_on:
       - keeper-node
-      - secret-store-signing-node
     env_file:
       - ${GATEWAY_ENV_FILE}
     environment:


### PR DESCRIPTION
## Description

New `--secret-store` cmd option to run secret store stack with tools.
Now that Secret store functionality was removed and deprecated from parity, lets make disable by default.

## Is this PR related with an open issue?

Related to Issue #51 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [x] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation
